### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repository-updater.yaml
+++ b/.github/workflows/repository-updater.yaml
@@ -1,5 +1,7 @@
 ---
 name: Repository Updater
+permissions:
+  contents: read
 
 # yamllint disable-line rule:truthy
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/elcajon-dev/repository-edge/security/code-scanning/2](https://github.com/elcajon-dev/repository-edge/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow appears to primarily involve running actions and does not explicitly use the `GITHUB_TOKEN` for repository operations, we will set the permissions to the minimal level required: `contents: read`. This ensures that the workflow has only the necessary permissions and mitigates potential security risks.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This is appropriate since there is only one job (`publish`) in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
