### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,9 @@
 name: Lint
 
 # yamllint disable-line rule:truthy
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,10 +1,10 @@
 ---
 name: Lint
 
-# yamllint disable-line rule:truthy
 permissions:
   contents: read
 
+# yamllint disable-line rule:truthy
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/elcajon-dev/repository-edge/security/code-scanning/1](https://github.com/elcajon-dev/repository-edge/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow is for linting, it likely only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the least privilege necessary, reducing the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
